### PR TITLE
Fix: MuttConfig missing validator

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -69,6 +69,7 @@ class MuttConfig {
       validators: {
         required: validators.RequiredValidator,
         booleanRequired: validators.BooleanRequiredValidator,
+        booleanTrue: validators.BooleanTrueValidator,
         length: validators.LengthValidator,
         integer: validators.IntegerValidator,
         regex: validators.RegexValidator,


### PR DESCRIPTION
# Description

Adds missing BooleanTrue validator to MuttConfig

Fixes #17 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
